### PR TITLE
Updates and bugfixes for the WezTerm color config

### DIFF
--- a/Wezterm/Mountain.toml
+++ b/Wezterm/Mountain.toml
@@ -8,5 +8,9 @@ cursor_fg = "#0f0f0f"
 cursor_border = "#262626"
 split = "#4c4c4c"
 
-ansi = [ "#8f8aac", "#ac8a8c", "#8aac8b", "#aca98a", "#8aabac", "#ac8aac","#8aabac", "#e7e7e8" ]
-brights = [ "#a39ec4", "#c49ea0", "#9ec49f", "#c4c19e", "#9ec3c4", "#c49ec4", "#9ec3c4", "#f0f0f0" ]
+ansi = [ "#0f0f0f", "#ac8a8c", "#8aac8b", "#aca98a", "#8aabac", "#ac8aac","#8aabac", "#e7e7e8" ]
+brights = [ "#262626", "#c49ea0", "#9ec49f", "#c4c19e", "#9ec3c4", "#c49ec4", "#9ec3c4", "#f0f0f0" ]
+
+[metadata]
+name = 'Mountain (Fuji)'
+orgin_url = 'https://github.com/mountain-theme/Mountain'

--- a/Wezterm/Mountain.toml
+++ b/Wezterm/Mountain.toml
@@ -13,4 +13,4 @@ brights = [ "#262626", "#c49ea0", "#9ec49f", "#c4c19e", "#9ec3c4", "#c49ec4", "#
 
 [metadata]
 name = 'Mountain (Fuji)'
-orgin_url = 'https://github.com/mountain-theme/Mountain'
+origin_url = 'https://github.com/mountain-theme/Mountain'

--- a/Wezterm/README.md
+++ b/Wezterm/README.md
@@ -8,7 +8,7 @@ Note: The format for this file was stolen from the catppuccin repo!
 local wezterm = require("wezterm")
 
 return {
-    color_scheme = "Mountain",
+    color_scheme = "Mountain (Fuji)",
     -- your config
   }
 ```


### PR DESCRIPTION
Fixes an error with the colors where the hexcode should be black, not purple.

Adds support for WezTerm colorscheme metadata feature, and update the `README.md` to reflect that.